### PR TITLE
fix: Sync images to worker registry

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,6 +27,10 @@ jobs:
     - name: Push docker image
       run: |
         docker push ${{ env.IMAGE_NAME }}
+    - name: Sync image to worker registry
+      uses: hyuabot-developers/hyuabot-infrastructure/.github/actions/sync-local-registry@a091ea37f391ae60eb7828325782a397cc7cae9c
+      with:
+        image: ${{ env.IMAGE_NAME }}
     - name: Remove docker image
       run: |
         docker rmi ${{ env.IMAGE_NAME }}


### PR DESCRIPTION
## Summary

- Synchronize each newly pushed image from the first node registry to the worker node registry.
- Pin the shared synchronization action to an immutable infrastructure commit.

## Root Cause

The two K3s nodes resolve `localhost:5000` to separate Docker registries, so pushing an image on the first node does not make it available to workloads scheduled on the worker.

## Impact

Deployment now completes only after the worker registry contains the same image config and layers. The registry remains bound locally on each server and is not exposed publicly.

## Validation

- Parsed the workflow YAML successfully.
- Passed `git diff --check`.
- Verified the pinned shared action in a production backend deployment.