### PR TITLE
fix: Publish images from Mac build runner

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   publish:
     if: github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true
-    uses: hyuabot-developers/hyuabot-infrastructure/.github/workflows/publish-immutable-image.yml@accefba87348b747359be6ee4a2ed8d16ca625f6
+    uses: hyuabot-developers/hyuabot-infrastructure/.github/workflows/publish-immutable-image.yml@e26660725b546d1de4021f5ac95f1be6c4c17c35
     with:
       image-repository: localhost:5000/hyuabot-building-updater
       no-cache: ${{ github.event_name == 'workflow_dispatch' && inputs['no-cache'] }}


### PR DESCRIPTION
## Summary

- Pin the immutable image workflow to the cross-platform Zsh fix.
- Keep MacBook-first builds and explicit offline fallback behavior unchanged.

## Root Cause

The previous reusable workflow invoked the registry publication action with an absolute Zsh executable. The macOS Actions runner rejected that shell format before publication or cleanup started.

## Impact

Merged changes can build on the MacBook, publish the immutable image to both node-local registries, remove local Docker copies, and deploy the commit-SHA tag.

## Validation

- Parsed the deployment workflow as YAML.
- Ran `git diff --check`.
- The merged workflow will be verified with an actual MacBook build and registry publication.