### PR TITLE
fix: Use the default registry host

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   publish:
     if: github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true
-    uses: hyuabot-developers/hyuabot-infrastructure/.github/workflows/publish-immutable-image.yml@e26660725b546d1de4021f5ac95f1be6c4c17c35
+    uses: hyuabot-developers/hyuabot-infrastructure/.github/workflows/publish-immutable-image.yml@8f1f01759d39340962b33d8cbba4835980715a4c
     with:
       image-repository: localhost:5000/hyuabot-building-updater
       no-cache: ${{ github.event_name == 'workflow_dispatch' && inputs['no-cache'] }}


### PR DESCRIPTION
## Summary

- Pin immutable image publication to the workflow with the default first-node registry host.
- Keep MacBook-first builds and explicit offline fallback unchanged.

## Root Cause

The public first-node hostname was previously sourced only from optional repository secrets, leaving MacBook publication without an SSH destination.

## Impact

Merged images can be transferred to the first-node registry without duplicating a public hostname as a Secret. SSH authentication remains unchanged.

## Validation

- Parsed the deployment workflow as YAML.
- Ran `git diff --check`.
- The merged workflow will be verified with an actual MacBook build and publication.